### PR TITLE
feat: add 16x.engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repo has all the resources you need to reach Senior Software Engineer!
 - [Saiyan Growth Letter](https://open.substack.com/pub/tigerabrodi)
 - [Software Design: Tidy First?](https://open.substack.com/pub/tidyfirst)
 - [Dev Interrupted](https://open.substack.com/users/89759436-dev-interrupted?utm_source=mentions)
+- [16x Engineer](https://16x.engineer/)
 
 ### Staying up-to-date
 


### PR DESCRIPTION
Add 16x Engineer created by myself: https://16x.engineer/

It is a website dedicated to resources on Software Engineer Career and Personal Growth, with a focus on Asia and Singapore tech industry.

Since there is no dedicated website category, I have parked in under newsletter (the website does have its own newsletter).