### PR TITLE
add hyperskill link to recommended websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ This repo has all the resources you need to reach Senior Software Engineer!
 - [GreatFrontEnd](https://www.greatfrontend.com/)
 - [Scrimba interactive courses](https://scrimba.com)
 - [KodeKloud](https://www.kodekloud.com)
+- [Hyperskill](https://hyperskill.org/tracks)
 
 ## Papers
 


### PR DESCRIPTION
I think it with might be good to add link to Hyperskill - https://hyperskill.org/tracks
I known it for a short time, 5 months. You can learn topics and make guided projects 
even if you are not premium user.