### PR TITLE
Add AI Dev Jobs to Platforms > Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,9 @@ This repo has all the resources you need to reach Senior Software Engineer!
 - [Interview Kickstart](https://learn.interviewkickstart.com/ace-your-mock-interview)
 - [AI Interview Coach](https://em-tools.io/interview-prep)
 
+### Job boards
+- [AI Dev Jobs](https://aidevboard.com) - Job board focused on AI and machine learning engineering roles, with 7,400+ jobs from 400+ companies and a free REST API.
+
 ## Helpful Tools
 - [WriteEdge for writing tech specs](https://www.writeedge.ai/)
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Platforms section under a new **Job boards** subsection.

AI Dev Jobs is a job board focused on AI/ML engineering roles with:
- 7,400+ job listings from 400+ companies
- Average salary of $225k
- Free REST API and MCP server for programmatic access
- Searchable by role, company, location, and salary

This is a useful resource for engineers looking to advance into AI/ML roles as part of their path to senior engineer.