### PR TITLE
Add missing 'Helpful Tools' entry to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo has all the resources you need to reach Senior Software Engineer!
 - [Communities](#communities)
 - [LinkedIn](#linkedin)
 - [Platforms](#platforms)
+- [Helpful Tools](#helpful-tools)
 - [Other catalogs](#other-catalogs)
 
 ## Newsletters


### PR DESCRIPTION
The **Helpful Tools** section (it sits between *Platforms* and *Other catalogs* in the README) was missing from the table of contents, so there's no way to jump to it from the TOC.

Added `- [Helpful Tools](#helpful-tools)` in the correct document order (between Platforms and Other catalogs). The anchor matches the `## Helpful Tools` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)