### PR TITLE
Add PracHub to Interview prep > Coding interview

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ This repo has all the resources you need to reach Senior Software Engineer!
 - [NeetCode](https://www.neetcode.io)
 - [PyPup](https://www.pypup.com)
 - [Codemia](https://codemia.io)
+- [PracHub](https://prachub.com)
 - [bugfree.ai](https://bugfree.ai?utm_source=git-path-to-senior-engineer-handbook)
 
 #### Mock interviews


### PR DESCRIPTION
Adds **PracHub** (https://prachub.com) to Interview prep › Coding interview, alongside LeetCode, NeetCode, and Codemia.

**Disclosure: I'm affiliated with PracHub.**

PracHub is a free platform for practicing real tech-interview questions from 400+ companies — coding/DSA, SQL, system design, and behavioral — with an in-browser coding console. Same category as the other entries in this subsection. Happy to adjust placement/wording or close it if it's not a fit for the list.

Single-line addition, existing format preserved.