### PR TITLE
Add Jobs in JS to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ This repo has all the resources you need to reach Senior Software Engineer!
 
 ### Job boards
 - [AI Dev Jobs](https://aidevboard.com) - Job board focused on AI and machine learning engineering roles, with 7,400+ jobs from 400+ companies and a free REST API.
+- [Jobs in JS](https://jobsinjs.com/) - Job board for JavaScript developers.
 
 ## Helpful Tools
 - [WriteEdge for writing tech specs](https://www.writeedge.ai/)


### PR DESCRIPTION
Adding https://jobsinjs.com/ to the Job boards section - a job board for JavaScript devs.